### PR TITLE
feat: add 'required' attribute for Option fields

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -117,10 +117,11 @@ enum Attribute {
     SkipSuffix,
     Tuple,
     Adapter,
+    Required,
 }
 
 impl Attribute {
-    const ALL: [Self; 9] = [
+    const ALL: [Self; 10] = [
         Self::Default,
         Self::Into,
         Self::Repeat,
@@ -130,6 +131,7 @@ impl Attribute {
         Self::SkipSuffix,
         Self::Tuple,
         Self::Adapter,
+        Self::Required,
     ];
 
     const fn as_str(self) -> &'static str {
@@ -143,6 +145,7 @@ impl Attribute {
             Attribute::SkipSuffix => "skip_suffix",
             Attribute::Tuple => "tuple",
             Attribute::Adapter => "adapter",
+            Attribute::Required => "required",
         }
     }
 }
@@ -291,7 +294,11 @@ impl BuilderField {
             };
 
         let (ty, wrapped_option) = if let Some(ty) = get_single_generic(&value.ty, Some("Option")) {
-            (ty, true)
+            if attr.required {
+                (&value.ty, false)
+            } else {
+                (ty, true)
+            }
         } else {
             (&value.ty, false)
         };
@@ -400,6 +407,7 @@ pub struct FieldAttr {
     /// None              -> tuple is passed as a value
     pub tuple: Option<Option<Vec<Ident>>>,
     pub adapter: Option<Adapter>,
+    pub required: bool,
 }
 
 impl FieldAttr {
@@ -611,6 +619,12 @@ impl FieldAttr {
                     };
 
                     out.adapter = Some(adapters);
+                }
+                Attribute::Required => {
+                    if out.required {
+                        bail!(ident.span() => "`required` may only be used once.");
+                    }
+                    out.required = true;
                 }
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,10 @@
 //!
 //! Specify a default value for the field to have, or use [`Default::default`]
 //!
+//! ### **`required`**
+//!
+//! Force a field to be specified, even if it is an `Option`.  Normally, `Option` fields are optional.
+//!
 //! ### **`repeat`**
 //!
 //! Allow any structure which supports [`FromIterator`] to be specified by calling the function
@@ -272,6 +276,32 @@ mod util;
 ///     .a(42)
 ///     .build();
 /// assert_eq!(foo, Foo { a: 42, b: std::f32::consts::PI });
+/// ```
+///
+/// ## **`required`**
+///
+/// Force a field to be specified, even if it is an `Option`.  Normally, `Option` fields are
+/// optional.
+///
+/// ```
+/// # use bauer::Builder;
+/// # const _: &str = stringify!(
+/// #[derive(Builder)]
+/// # );
+/// # #[derive(Builder, PartialEq, Debug)]
+/// pub struct Foo {
+///     #[builder(required)]
+///     a: Option<u32>,
+/// }
+///
+/// let foo = Foo::builder().a(Some(42)).build().unwrap();
+/// assert_eq!(foo, Foo { a: Some(42) });
+///
+/// let foo = Foo::builder().a(None).build().unwrap();
+/// assert_eq!(foo, Foo { a: None });
+///
+/// let foo_err = Foo::builder().build();
+/// assert!(foo_err.is_err());
 /// ```
 ///
 /// ## **`repeat`**

--- a/tests/required_option.rs
+++ b/tests/required_option.rs
@@ -1,0 +1,49 @@
+use bauer::Builder;
+
+#[test]
+fn required_option_owned() {
+    #[derive(Builder, Debug, PartialEq)]
+    struct Foo {
+        #[builder(required)]
+        field: Option<u32>,
+    }
+
+    let foo = Foo::builder()
+        .field(Some(42))
+        .build()
+        .unwrap();
+    assert_eq!(foo, Foo { field: Some(42) });
+
+    let foo_none = Foo::builder()
+        .field(None)
+        .build()
+        .unwrap();
+    assert_eq!(foo_none, Foo { field: None });
+
+    let err = Foo::builder().build().unwrap_err();
+    // The exact error name depends on the field name
+    assert!(format!("{:?}", err).contains("MissingField"));
+}
+
+#[test]
+fn required_option_type_state() {
+    #[derive(Builder, Debug, PartialEq)]
+    #[builder(kind = "type-state")]
+    struct Foo {
+        #[builder(required)]
+        field: Option<u32>,
+    }
+
+    let foo = Foo::builder()
+        .field(Some(42))
+        .build();
+    assert_eq!(foo, Foo { field: Some(42) });
+
+    let foo_none = Foo::builder()
+        .field(None)
+        .build();
+    assert_eq!(foo_none, Foo { field: None });
+
+    // This should fail to compile if I uncomment it
+    // let foo_fail = Foo::builder().build();
+}


### PR DESCRIPTION
Added a `required` attribute for `Option` fields that are normally unwrapped to be optional. This allows forcing a field to be specified even if its type is `Option<T>`. This works for both default (owned/borrowed) and type-state builders. Fixes #55.