### PR TITLE
Add `on` attribute

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,27 +15,35 @@ concurrency:
   cancel-in-progress: true
 name: test
 jobs:
-  test-stable:
+  test-msrv:
+    # check that we can build using the minimal rust version that is specified by this crate
     runs-on: ubuntu-latest
-    name: ubuntu / stable
+    # we use a matrix here just because env can't be used in job names
+    # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
+    strategy:
+      matrix:
+        msrv: ["1.85"]
+    name: ubuntu / ${{ matrix.msrv }}
     steps:
       - uses: actions/checkout@v6.0.2
         with:
           submodules: true
-      - name: Install stable
+      - name: Install ${{ matrix.msrv }}
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.msrv }}
+      - uses: actions/cache@v5.0.4
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-cargo
       - name: cargo generate-lockfile
         # enable this ci template to run regardless of whether the lockfile is checked in or not
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile
-      # https://twitter.com/jonhoo/status/1571290371124260865
       - name: cargo test --locked
-        run: cargo test --locked --all-features --all-targets
-      # https://github.com/rust-lang/cargo/issues/6669
+        run: cargo +${{ matrix.msrv }} test --locked --all-features --all-targets
       - name: cargo test --doc
-        run: cargo test --locked --all-features --doc
+        run: cargo +${{ matrix.msrv }} test --locked --all-features --doc
   test-beta:
     runs-on: ubuntu-latest
     name: ubuntu / beta

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,7 +128,7 @@ jobs:
       - name: cargo update -Zminimal-versions
         run: cargo +nightly update -Zminimal-versions
       - name: cargo test
-        run: cargo test --locked --all-features --all-targets
+        run: cargo test --locked --all-features --all-targets -- --skip ui
   os-check:
     # run cargo test on mac and windows
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 name: test
 jobs:
-  test-msrv:
+  test-ui:
     # check that we can build using the minimal rust version that is specified by this crate
     runs-on: ubuntu-latest
     # we use a matrix here just because env can't be used in job names
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         msrv: ["1.85"]
-    name: ubuntu / ${{ matrix.msrv }}
+    name: ubuntu / ${{ matrix.msrv }} / ui
     steps:
       - uses: actions/checkout@v6.0.2
         with:
@@ -41,9 +41,30 @@ jobs:
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile
       - name: cargo test --locked
-        run: cargo +${{ matrix.msrv }} test --locked --all-features --all-targets
+        run: cargo +${{ matrix.msrv }} test --locked --all-features --test ui
       - name: cargo test --doc
         run: cargo +${{ matrix.msrv }} test --locked --all-features --doc
+  test-stable:
+    runs-on: ubuntu-latest
+    name: ubuntu / stable
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          submodules: true
+      - name: Install stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - name: cargo generate-lockfile
+        # enable this ci template to run regardless of whether the lockfile is checked in or not
+        if: hashFiles('Cargo.lock') == ''
+        run: cargo generate-lockfile
+      # https://twitter.com/jonhoo/status/1571290371124260865
+      - name: cargo test --locked
+        run: cargo test --locked --all-features --all-targets -- --skip ui
+      # https://github.com/rust-lang/cargo/issues/6669
+      - name: cargo test --doc
+        run: cargo test --locked --all-features --doc
   test-beta:
     runs-on: ubuntu-latest
     name: ubuntu / beta
@@ -61,7 +82,7 @@ jobs:
         run: cargo generate-lockfile
       # https://twitter.com/jonhoo/status/1571290371124260865
       - name: cargo test --locked
-        run: cargo test --locked --all-features --all-targets -- --skip ui # UI tests are broken in beta since the compiler text changed
+        run: cargo test --locked --all-features --all-targets -- --skip ui
       # https://github.com/rust-lang/cargo/issues/6669
       - name: cargo test --doc
         run: cargo test --locked --all-features --doc
@@ -128,4 +149,4 @@ jobs:
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile
       - name: cargo test
-        run: cargo test --locked --all-features --all-targets
+        run: cargo test --locked --all-features --all-targets -- --skip ui

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ a `#[builder(..)]` attribute.  For a more detailed description and examples, che
 | [`build_fn`]                                 | Set details about the build function (`attributes`, `doc`, `rename`)                                        | `build_fn(...)`                              |
 | [`builder_fn`]                               | Set details about the builder function added to the struct (`attributes`, `doc`, `rename`)                  | `builder_fn(...)`                            |
 | [`error`]                                    | Set details about the generated error enum (`attributes`, `doc`, `rename`, `force`)                         | `error(...)`                                 |
+| [`on`]                                       | Apply field attributes to fields that match a specific type pattern                                         | `on(<type> => <attributes ...>)`             |
 
 [`kind`]: https://docs.rs/bauer/latest/bauer/derive.Builder.html#kind
 [`const`]: https://docs.rs/bauer/latest/bauer/derive.Builder.html#const
@@ -91,6 +92,7 @@ a `#[builder(..)]` attribute.  For a more detailed description and examples, che
 [`build_fn`]: https://docs.rs/bauer/latest/bauer/derive.Builder.html#build_fn
 [`builder_fn`]: https://docs.rs/bauer/latest/bauer/derive.Builder.html#builder_fn
 [`error`]: https://docs.rs/bauer/latest/bauer/derive.Builder.html#error
+[`on`]: https://docs.rs/bauer/latest/bauer/derive.Builder.html#on
 
 ### Field Attributes
 

--- a/bauer-macros/src/attr/builder.rs
+++ b/bauer-macros/src/attr/builder.rs
@@ -4,7 +4,7 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use strum::{AsRefStr, IntoStaticStr, VariantArray};
 use syn::{
-    Ident, ItemConst, LitStr, Token, Visibility,
+    Ident, ItemConst, LitStr, Token, Type, Visibility,
     ext::IdentExt,
     parse::{Parse, ParseStream},
     parse_quote,
@@ -61,6 +61,12 @@ impl Parse for Kind {
     }
 }
 
+#[derive(Clone, Debug)]
+pub(crate) struct On {
+    pattern: Type,
+    replacement: TokenStream,
+}
+
 #[derive(Clone, Copy, VariantArray, IntoStaticStr, AsRefStr, Debug, PartialEq, Eq)]
 #[strum(serialize_all = "snake_case")]
 enum Attribute {
@@ -76,6 +82,7 @@ enum Attribute {
     BuildFn,
     BuilderFn,
     Error,
+    On,
 }
 
 impl Attribute {
@@ -124,6 +131,7 @@ pub struct BuilderAttr {
     pub build_fn: BuildFnAttr,
     pub builder_fn: BuildFnAttr,
     pub error: ErrorAttr,
+    pub on: Vec<On>,
 }
 
 impl BuilderAttr {
@@ -139,6 +147,7 @@ impl BuilderAttr {
             build_fn: BuildFnAttr::default_build(),
             builder_fn: BuildFnAttr::default_builder(),
             error: Default::default(),
+            on: Default::default(),
         }
     }
 

--- a/bauer-macros/src/attr/builder.rs
+++ b/bauer-macros/src/attr/builder.rs
@@ -68,16 +68,16 @@ pub(crate) struct On {
 }
 
 impl On {
-    pub fn apply(&self, field_ty: &Type) -> Option<TokenStream> {
+    pub fn apply(&self, field_ty: &Type) -> syn::Result<Option<TokenStream>> {
         use crate::util::pattern::{pattern_match_type, replace};
 
         let mut out = Vec::new();
         let matches = pattern_match_type(&self.pattern, field_ty, &mut out);
         if !matches {
-            return None;
+            return Ok(None);
         }
 
-        Some(replace(&out, self.attributes.clone()))
+        Ok(Some(replace(&out, self.attributes.clone())?))
     }
 }
 

--- a/bauer-macros/src/attr/builder.rs
+++ b/bauer-macros/src/attr/builder.rs
@@ -64,13 +64,40 @@ impl Parse for Kind {
 #[derive(Clone, Debug)]
 pub(crate) struct On {
     pattern: Type,
-    replacement: TokenStream,
+    attributes: TokenStream,
+}
+
+impl On {
+    pub fn apply(&self, field_ty: &Type) -> Option<TokenStream> {
+        use crate::util::pattern::{pattern_match_type, replace};
+
+        let mut out = Vec::new();
+        let matches = pattern_match_type(&self.pattern, field_ty, &mut out);
+        if !matches {
+            return None;
+        }
+
+        Some(replace(&out, self.attributes.clone()))
+    }
+}
+
+impl Parse for On {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let pattern: Type = input.parse()?;
+        let _arrow: Token![=>] = input.parse()?;
+        let attributes: TokenStream = input.parse()?;
+        Ok(Self {
+            pattern,
+            attributes,
+        })
+    }
 }
 
 #[derive(Clone, Copy, VariantArray, IntoStaticStr, AsRefStr, Debug, PartialEq, Eq)]
 #[strum(serialize_all = "snake_case")]
+#[repr(usize)]
 enum Attribute {
-    Kind,
+    Kind = 0,
     Prefix,
     Suffix,
     Visibility,
@@ -86,6 +113,24 @@ enum Attribute {
 }
 
 impl Attribute {
+    #[inline]
+    const fn single_use(&self) -> bool {
+        match self {
+            Attribute::Kind => true,
+            Attribute::Prefix => true,
+            Attribute::Suffix => true,
+            Attribute::Visibility => true,
+            Attribute::Crate => true,
+            Attribute::Const => true,
+            Attribute::Attributes => false,
+            Attribute::Doc => false,
+            Attribute::BuildFn => true,
+            Attribute::BuilderFn => true,
+            Attribute::Error => true,
+            Attribute::On => false,
+        }
+    }
+
     fn matches(self, ident: &Ident) -> bool {
         if ident == self.as_ref() {
             return true;
@@ -132,6 +177,7 @@ pub struct BuilderAttr {
     pub builder_fn: BuildFnAttr,
     pub error: ErrorAttr,
     pub on: Vec<On>,
+    pub set_fields: [bool; const { Attribute::VARIANTS.len() }],
 }
 
 impl BuilderAttr {
@@ -148,6 +194,7 @@ impl BuilderAttr {
             builder_fn: BuildFnAttr::default_builder(),
             error: Default::default(),
             on: Default::default(),
+            set_fields: Default::default(),
         }
     }
 
@@ -192,116 +239,69 @@ impl BuilderAttr {
         }
     }
 
-    pub fn parse(input: ParseStream, vis: Visibility) -> syn::Result<Self> {
-        let mut out = Self::new(vis);
-
-        let mut kind_set = false;
-        let mut prefix_set = false;
-        let mut suffix_set = false;
-        let mut vis_set = false;
-        let mut crate_set = false;
-        let mut build_fn_set = false;
-        let mut builder_fn_set = false;
-        let mut error_set = false;
-
+    pub fn parse(&mut self, input: ParseStream) -> syn::Result<()> {
         while input.peek(Ident::peek_any) {
             let ident = Ident::parse_any(input)?;
+            let attr = Attribute::parse(&ident)?;
+
+            if self.set_fields[attr as usize] && attr.single_use() {
+                bail!(ident.span() => "`{}` may only be used once", <&str>::from(attr));
+            }
+            self.set_fields[attr as usize] = true;
+
             match Attribute::parse(&ident)? {
                 Attribute::Kind => {
-                    if kind_set {
-                        bail!(ident.span() => "`kind` may only be used once");
-                    }
-
                     let _: Token![=] = input.parse()?;
-                    out.kind = input.parse()?;
-                    kind_set = true;
+                    self.kind = input.parse()?;
                 }
                 Attribute::Prefix => {
-                    if prefix_set {
-                        bail!(ident.span() => "`prefix` may only be used once");
-                    }
-
                     let _: Token![=] = input.parse()?;
-                    out.prefix = input.parse::<LitStr>()?.value();
-                    prefix_set = true;
+                    self.prefix = input.parse::<LitStr>()?.value();
                 }
                 Attribute::Suffix => {
-                    if suffix_set {
-                        bail!(ident.span() => "`suffix` may only be used once");
-                    }
-
                     let _: Token![=] = input.parse()?;
-                    out.suffix = input.parse::<LitStr>()?.value();
-                    suffix_set = true;
+                    self.suffix = input.parse::<LitStr>()?.value();
                 }
                 Attribute::Visibility => {
-                    if vis_set {
-                        bail!(ident.span() => "`visibility` may only be used once");
-                    }
-
                     let _: Token![=] = input.parse()?;
-                    out.vis = input.parse()?;
-                    vis_set = true;
+                    self.vis = input.parse()?;
                 }
                 Attribute::Crate => {
-                    if crate_set {
-                        bail!(ident.span() => "`crate` may only be used once");
-                    }
-
                     let _: Token![=] = input.parse()?;
-                    out.krate = input.parse()?;
-                    crate_set = true;
+                    self.krate = input.parse()?;
                 }
                 Attribute::Const => {
-                    if out.konst {
-                        bail!(ident.span() => "`const` may only be used once");
-                    }
-
-                    out.konst = true;
+                    self.konst = true;
                 }
                 Attribute::Attributes => {
                     let attrs = parethesised_or_braced(input)?;
 
                     if !attrs.is_empty() {
-                        parse_attributes(&attrs, &mut out.attributes)?;
+                        parse_attributes(&attrs, &mut self.attributes)?;
                     }
                 }
                 Attribute::Doc => {
                     let attrs = parethesised_or_braced(input)?;
 
                     if !attrs.is_empty() {
-                        parse_docs(&attrs, ident.span(), &mut out.attributes)?;
+                        parse_docs(&attrs, ident.span(), &mut self.attributes)?;
                     }
                 }
                 Attribute::BuildFn => {
-                    if build_fn_set {
-                        bail!(ident.span() => "`build_fn` may only be used once");
-                    }
-
                     let build_fn = parethesised_or_braced(input)?;
-                    out.build_fn.parse(&build_fn)?;
-
-                    build_fn_set = true;
+                    self.build_fn.parse(&build_fn)?;
                 }
                 Attribute::BuilderFn => {
-                    if builder_fn_set {
-                        bail!(ident.span() => "`builder_fn` may only be used once");
-                    }
-
                     let builder_fn = parethesised_or_braced(input)?;
-                    out.builder_fn.parse(&builder_fn)?;
-
-                    builder_fn_set = true;
+                    self.builder_fn.parse(&builder_fn)?;
                 }
                 Attribute::Error => {
-                    if error_set {
-                        bail!(ident.span() => "`build_fn` may only be used once");
-                    }
-
                     let error = parethesised_or_braced(input)?;
-                    out.error = ErrorAttr::parse(&error)?;
-
-                    error_set = true;
+                    self.error = ErrorAttr::parse(&error)?;
+                }
+                Attribute::On => {
+                    let inner = parethesised_or_braced(input)?;
+                    self.on.push(inner.parse()?);
                 }
             }
 
@@ -312,6 +312,6 @@ impl BuilderAttr {
             }
         }
 
-        Ok(out)
+        Ok(())
     }
 }

--- a/bauer-macros/src/attr/builder.rs
+++ b/bauer-macros/src/attr/builder.rs
@@ -71,13 +71,9 @@ impl On {
     pub fn apply(&self, field_ty: &Type) -> syn::Result<Option<TokenStream>> {
         use crate::util::pattern::{pattern_match_type, replace};
 
-        let mut out = Vec::new();
-        let matches = pattern_match_type(&self.pattern, field_ty, &mut out);
-        if !matches {
-            return Ok(None);
-        }
-
-        Ok(Some(replace(&out, self.attributes.clone())?))
+        pattern_match_type(&self.pattern, field_ty)
+            .map(|matches| replace(&matches, self.attributes.clone()))
+            .transpose()
     }
 }
 

--- a/bauer-macros/src/attr/field.rs
+++ b/bauer-macros/src/attr/field.rs
@@ -352,7 +352,7 @@ impl BuilderField {
             let mut out = FieldAttr::default();
 
             for on in &builder_attr.on {
-                if let Some(replaced) = on.apply(&value.ty) {
+                if let Some(replaced) = on.apply(&value.ty)? {
                     syn::parse::Parser::parse2(
                         |input: ParseStream| out.parse(input, builder_attr, value, wrapped_option),
                         replaced,

--- a/bauer-macros/src/attr/field.rs
+++ b/bauer-macros/src/attr/field.rs
@@ -1,23 +1,23 @@
-use std::ops::Range;
+use std::{cmp::Ordering, ops::Range};
 
 use convert_case::{Case, Casing};
 use proc_macro2::{Span, TokenStream};
 use quote::{ToTokens, format_ident, quote, quote_spanned};
 use strum::{AsRefStr, IntoStaticStr, VariantArray};
 use syn::{
-    Expr, ExprClosure, Field, Ident, Index, LitStr, Pat, Path, Token, TraitBound, Type, braced,
+    Expr, ExprClosure, Field, Ident, Index, LitStr, Pat, Path, Token, TraitBound, Type,
     parenthesized,
     parse::{Parse, ParseStream},
     parse_quote, parse_quote_spanned,
     spanned::Spanned,
-    token::{Brace, Paren},
+    token::Paren,
 };
 
 use crate::{
     BuilderAttr, Kind,
     util::{
         escape_ident,
-        parse::{parse_attributes, parse_docs},
+        parse::{parethesised_or_braced, parse_attributes, parse_docs},
     },
 };
 
@@ -119,8 +119,9 @@ macro_rules! bail {
 
 #[derive(Clone, Copy, VariantArray, IntoStaticStr, AsRefStr, Debug, PartialEq, Eq)]
 #[strum(serialize_all = "snake_case")]
+#[repr(usize)]
 enum Attribute {
-    Default,
+    Default = 0,
     Into,
     Repeat,
     RepeatN,
@@ -151,6 +152,25 @@ impl Attribute {
         match self {
             Self::Attributes => ident == "attribute",
             _ => false,
+        }
+    }
+
+    #[inline]
+    const fn single_use(&self) -> bool {
+        match self {
+            Attribute::Default => true,
+            Attribute::Into => true,
+            Attribute::Repeat => true,
+            Attribute::RepeatN => true,
+            Attribute::Rename => true,
+            Attribute::SkipPrefix => true,
+            Attribute::SkipSuffix => true,
+            Attribute::Tuple => true,
+            Attribute::Adapter => true,
+            Attribute::Attributes => false,
+            Attribute::Doc => false,
+            Attribute::Collector => true,
+            Attribute::Skip => true,
         }
     }
 
@@ -328,14 +348,25 @@ impl BuilderField {
             (&value.ty, false)
         };
 
-        let mut attr: FieldAttr =
-            if let Some(attr) = value.attrs.iter().find(|a| a.path().is_ident("builder")) {
+        let mut attr: FieldAttr = {
+            let mut out = FieldAttr::default();
+
+            for on in &builder_attr.on {
+                if let Some(replaced) = on.apply(&value.ty) {
+                    syn::parse::Parser::parse2(
+                        |input: ParseStream| out.parse(input, builder_attr, value, wrapped_option),
+                        replaced,
+                    )?;
+                }
+            }
+
+            for attr in value.attrs.iter().filter(|a| a.path().is_ident("builder")) {
                 attr.parse_args_with(|input: ParseStream| {
-                    FieldAttr::parse(input, builder_attr, value, wrapped_option)
-                })?
-            } else {
-                FieldAttr::default()
-            };
+                    out.parse(input, builder_attr, value, wrapped_option)
+                })?;
+            }
+            out
+        };
 
         if !attr.attributes.iter().any(|a| a.path().is_ident("doc")) {
             attr.attributes.reserve(value.attrs.len());
@@ -843,24 +874,29 @@ impl FieldAttr {
     }
 
     fn parse(
+        &mut self,
         input: syn::parse::ParseStream,
         builder_attr: &BuilderAttr,
         field: &Field,
         wrapped_option: bool,
-    ) -> syn::Result<Self> {
-        let mut out = FieldAttr::default();
+    ) -> syn::Result<()> {
         let field_ident = field.ident.as_ref().unwrap();
+
+        let mut set = [false; const { Attribute::VARIANTS.len() }];
 
         let mut n_attr = 0;
         while input.peek(syn::Ident) {
             let ident: Ident = input.parse()?;
-            match Attribute::parse(&ident)? {
-                Attribute::Default => {
-                    if out.default.is_some() {
-                        bail!(ident.span() => "`default` may only be used once");
-                    }
+            let attr = Attribute::parse(&ident)?;
 
-                    if out.repeat.is_some() {
+            if set[attr as usize] && attr.single_use() {
+                bail!(ident.span() => "`{}` may only be used once", attr.as_str());
+            }
+            set[attr as usize] = true;
+
+            match attr {
+                Attribute::Default => {
+                    if self.repeat.is_some() {
                         bail!(ident.span() => "`default` cannot be added with `repeat`");
                     }
 
@@ -883,14 +919,10 @@ impl FieldAttr {
                         DefaultAttr::Default { ident }
                     };
 
-                    out.default = Some(value)
+                    self.default = Some(value)
                 }
                 Attribute::Into => {
-                    if out.into.is_some() {
-                        bail!(ident.span() => "`into` may only be used once");
-                    }
-
-                    if out.adapter.is_some() {
+                    if self.adapter.is_some() {
                         bail!(ident.span() => "`into` cannot be added with `adapter`");
                     }
 
@@ -898,14 +930,10 @@ impl FieldAttr {
                         bail!(ident.span() => "`into` may not be used on const builders");
                     }
 
-                    out.into = Some(ident.span());
+                    self.into = Some(ident.span());
                 }
                 Attribute::Repeat => {
-                    if out.repeat.is_some() {
-                        bail!(ident.span() => "`repeat` may only be used once");
-                    }
-
-                    if out.default.is_some() {
+                    if self.default.is_some() {
                         bail!(ident.span() => "`repeat` cannot be added with `default`");
                     }
 
@@ -950,7 +978,7 @@ impl FieldAttr {
                         }
                     };
 
-                    out.repeat = Some(Repeat {
+                    self.repeat = Some(Repeat {
                         inner_ty: inner_ty.clone(),
                         len,
                         array,
@@ -958,7 +986,7 @@ impl FieldAttr {
                     });
                 }
                 Attribute::RepeatN => {
-                    let Some(rep) = &mut out.repeat else {
+                    let Some(rep) = &mut self.repeat else {
                         bail!(ident.span() => "`repeat_n` may only be used with `repeat`");
                     };
 
@@ -990,39 +1018,25 @@ impl FieldAttr {
                     };
                 }
                 Attribute::Rename => {
-                    if out.rename.is_some() {
-                        bail!(ident.span() => "`rename` may only be used once");
-                    }
-
                     let _: Token![=] = input.parse()?;
                     let s: LitStr = input.parse()?;
 
-                    out.rename = Some(s.parse()?);
+                    self.rename = Some(s.parse()?);
                 }
                 Attribute::SkipPrefix => {
-                    if out.skip_prefix {
-                        bail!(ident.span() => "`skip_prefix` may only be used once");
-                    }
-                    out.skip_prefix = true;
+                    self.skip_prefix = true;
                 }
                 Attribute::SkipSuffix => {
-                    if out.skip_suffix {
-                        bail!(ident.span() => "`skip_suffix` may only be used once");
-                    }
-                    out.skip_suffix = true;
+                    self.skip_suffix = true;
                 }
                 Attribute::Tuple => {
-                    if out.tuple.is_some() {
-                        bail!(ident.span() => "`tuple` may only be used once");
-                    }
-
-                    if out.adapter.is_some() {
+                    if self.adapter.is_some() {
                         bail!(ident.span() => "`tuple` cannot be added with `adapter`");
                     }
 
                     let tuple = match &field.ty {
                         Type::Tuple(tuple) => tuple,
-                        _ => match &out.repeat {
+                        _ => match &self.repeat {
                             Some(Repeat {
                                 inner_ty: Type::Tuple(tuple),
                                 ..
@@ -1039,30 +1053,26 @@ impl FieldAttr {
                         let idents = content.parse_terminated(Ident::parse, Token![,])?;
 
                         match tuple.elems.len().cmp(&idents.len()) {
-                            std::cmp::Ordering::Less => {
+                            Ordering::Less => {
                                 bail!(paren.span.join() => "More names than elements in tuple")
                             }
-                            std::cmp::Ordering::Equal => {}
-                            std::cmp::Ordering::Greater => {
+                            Ordering::Equal => {}
+                            Ordering::Greater => {
                                 bail!(paren.span.join() => "Fewer names than elements in tuple")
                             }
                         }
 
-                        out.tuple = Some(Some(idents.into_iter().collect()))
+                        self.tuple = Some(Some(idents.into_iter().collect()))
                     } else {
-                        out.tuple = Some(None)
+                        self.tuple = Some(None)
                     }
                 }
                 Attribute::Adapter => {
-                    if out.adapter.is_some() {
-                        bail!(ident.span() => "`adapter` may only be used once");
-                    }
-
-                    if out.tuple.is_some() {
+                    if self.tuple.is_some() {
                         bail!(ident.span() => "`adapter` cannot be added with `tuple`");
                     }
 
-                    if out.into.is_some() {
+                    if self.into.is_some() {
                         bail!(ident.span() => "`adapter` cannot be added with `into`");
                     }
 
@@ -1078,47 +1088,25 @@ impl FieldAttr {
                         return Err(la.error());
                     };
 
-                    out.adapter = Some(adapters);
+                    self.adapter = Some(adapters);
                 }
                 Attribute::Attributes => {
-                    let attrs;
-
-                    let la = input.lookahead1();
-                    if la.peek(Paren) {
-                        parenthesized!(attrs in input);
-                    } else if la.peek(Brace) {
-                        braced!(attrs in input);
-                    } else {
-                        return Err(la.error());
-                    }
+                    let attrs = parethesised_or_braced(input)?;
 
                     if !attrs.is_empty() {
-                        parse_attributes(&attrs, &mut out.attributes)?;
+                        parse_attributes(&attrs, &mut self.attributes)?;
                     }
                 }
                 Attribute::Doc => {
-                    let attrs;
-
-                    let la = input.lookahead1();
-                    if la.peek(Paren) {
-                        parenthesized!(attrs in input);
-                    } else if la.peek(Brace) {
-                        braced!(attrs in input);
-                    } else {
-                        return Err(la.error());
-                    }
+                    let attrs = parethesised_or_braced(input)?;
 
                     if !attrs.is_empty() {
-                        parse_docs(&attrs, ident.span(), &mut out.attributes)?;
+                        parse_docs(&attrs, ident.span(), &mut self.attributes)?;
                     }
                 }
                 Attribute::Collector => {
-                    let Some(repeat) = &mut out.repeat else {
+                    let Some(repeat) = &mut self.repeat else {
                         bail!(ident.span() => "`collector` may only be used with `repeat`");
-                    };
-
-                    if !matches!(repeat.collector, Collector::FromIterator { .. }) {
-                        bail!(ident.span() => "`collector` may only be used once");
                     };
 
                     if repeat.array {
@@ -1135,11 +1123,7 @@ impl FieldAttr {
                     };
                 }
                 Attribute::Skip => {
-                    if out.skip.is_set() {
-                        bail!(ident.span() => "`skip` may only be used once");
-                    }
-
-                    out.skip = if input.peek(Token![=]) {
+                    self.skip = if input.peek(Token![=]) {
                         let _: Token![=] = input.parse()?;
                         Skip::Expr {
                             ident,
@@ -1161,7 +1145,7 @@ impl FieldAttr {
 
         // validate the structure
         if n_attr != 1 {
-            if let Some(ident) = out.skip.ident() {
+            if let Some(ident) = self.skip.ident() {
                 bail!(
                     ident.span() =>
                     "`skip` may not be used with any other attributes"
@@ -1169,6 +1153,6 @@ impl FieldAttr {
             }
         }
 
-        Ok(out)
+        Ok(())
     }
 }

--- a/bauer-macros/src/lib.rs
+++ b/bauer-macros/src/lib.rs
@@ -37,20 +37,22 @@ fn builder_fn(input: &DeriveInput, builder_attr: &BuilderAttr, builder: &Ident) 
     }
 }
 
+fn parse_build_attr(input: &DeriveInput) -> syn::Result<BuilderAttr> {
+    let mut out = BuilderAttr::new(input.vis.clone());
+    for attr in input.attrs.iter().filter(|a| a.path().is_ident("builder")) {
+        attr.parse_args_with(|ps: ParseStream| out.parse(ps))?;
+    }
+    Ok(out)
+}
+
 #[proc_macro_derive(Builder, attributes(builder))]
 pub fn builder(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let ident = &input.ident;
-    let vis = &input.vis;
 
-    let attr = input.attrs.iter().find(|a| a.path().is_ident("builder"));
-    let builder_attr: BuilderAttr = if let Some(attr) = attr {
-        match attr.parse_args_with(|ps: ParseStream| BuilderAttr::parse(ps, vis.clone())) {
-            Ok(a) => a,
-            Err(e) => return e.to_compile_error().into(),
-        }
-    } else {
-        BuilderAttr::new(vis.clone())
+    let builder_attr: BuilderAttr = match parse_build_attr(&input) {
+        Ok(a) => a,
+        Err(e) => return e.to_compile_error().into(),
     };
 
     let data_struct = match input.data {

--- a/bauer-macros/src/util.rs
+++ b/bauer-macros/src/util.rs
@@ -7,6 +7,7 @@ use syn::{DeriveInput, Ident};
 use crate::BuilderField;
 
 pub mod parse;
+pub mod pattern;
 
 pub(crate) struct Replace<I: Iterator + Sized> {
     iter: std::iter::Enumerate<I>,

--- a/bauer-macros/src/util/pattern.rs
+++ b/bauer-macros/src/util/pattern.rs
@@ -3,6 +3,7 @@ use proc_macro2::TokenStream;
 use proc_macro2::TokenTree;
 use quote::ToTokens;
 use quote::TokenStreamExt;
+use quote::quote;
 use syn::Expr;
 use syn::GenericArgument;
 use syn::LitInt;
@@ -222,13 +223,13 @@ pub fn pattern_match_type(pattern: &Type, ty: &Type, out: &mut Vec<TokenStream>)
     }
 }
 
-pub fn replace(matches: &[TokenStream], stream: TokenStream) -> TokenStream {
+pub fn replace(matches: &[TokenStream], stream: TokenStream) -> syn::Result<TokenStream> {
     let mut out = TokenStream::new();
     let mut stream = stream.into_iter().peekable();
     while let Some(t) = stream.next() {
         let t = match t {
             TokenTree::Group(g) => {
-                let stream = replace(matches, g.stream());
+                let stream = replace(matches, g.stream())?;
                 let mut t = Group::new(g.delimiter(), stream);
                 t.set_span(g.span());
 
@@ -236,19 +237,34 @@ pub fn replace(matches: &[TokenStream], stream: TokenStream) -> TokenStream {
             }
             TokenTree::Ident(_) => t,
             TokenTree::Punct(ref p) if p.as_char() == '#' => {
-                if let Some(l) = stream.next_if(|t| {
-                    matches!(t, TokenTree::Literal(l) if {
-                        // This hurts...
-                        // TODO: figure out a better way to match integer literals
-                        syn::parse2::<LitInt>(l.into_token_stream()).is_ok()
-                    })
-                }) {
-                    let TokenTree::Literal(l) = l else {
-                        unreachable!("Checked Above");
-                    };
-                    let n = syn::parse2::<LitInt>(l.into_token_stream()).expect("checked above");
-                    matches[n.base10_parse::<usize>().unwrap()].to_tokens(&mut out);
-                    continue;
+                if let Some(peeked) = stream.peek() {
+                    match peeked {
+                        TokenTree::Literal(_) => {
+                            let Some(TokenTree::Literal(l)) = stream.next() else {
+                                unreachable!("peek was some and literal matched");
+                            };
+
+                            let int = syn::parse2::<LitInt>(l.to_token_stream())?;
+                            let n = int.base10_parse::<usize>()?;
+
+                            if let Some(m) = matches.get(n) {
+                                m.to_tokens(&mut out);
+                            } else {
+                                let err = format!(
+                                    "index out of bounds: there were {0} matches but the index is {1}, if you intended a literal '#{1}', use '# #{1}'",
+                                    matches.len(),
+                                    n,
+                                );
+                                return Err(syn::Error::new_spanned(quote! { #int #p }, err));
+                            }
+                            continue;
+                        }
+                        TokenTree::Punct(p) if p.as_char() == '#' => {
+                            // munch if we have a double `#`
+                            stream.next().expect("peek is some")
+                        }
+                        _ => t,
+                    }
                 } else {
                     t
                 }
@@ -258,7 +274,7 @@ pub fn replace(matches: &[TokenStream], stream: TokenStream) -> TokenStream {
         };
         out.append(t);
     }
-    out
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -558,7 +574,7 @@ mod test {
     macro_rules! test_replace {
         ([$({$($matches: tt)*}),*$(,)?] + { $($tt: tt)* } => $($out: tt)*) => {
             eprintln!("{} + {} => {}", stringify!([$({$($matches)*}),*]), stringify!($($tt)*), stringify!($($out)*));
-            let x = replace(&[$(quote! { $($matches)* }),*], quote! { $($tt)* });
+            let x = replace(&[$(quote! { $($matches)* }),*], quote! { $($tt)* }).unwrap();
             assert_eq!(x.to_string(), quote! { $($out)* }.to_string());
         };
     }
@@ -586,7 +602,7 @@ mod test {
         let out = replace(
             &out,
             quote! { repeat = (#0, #1), adapter = |name: impl Into<#0>, value: Value| (name.into(), value) },
-        );
+        ).unwrap();
         dbg!(out.to_string());
         assert_eq!(
             out.to_string(),

--- a/bauer-macros/src/util/pattern.rs
+++ b/bauer-macros/src/util/pattern.rs
@@ -1,7 +1,11 @@
+use proc_macro2::Group;
 use proc_macro2::TokenStream;
+use proc_macro2::TokenTree;
 use quote::ToTokens;
+use quote::TokenStreamExt;
 use syn::Expr;
 use syn::GenericArgument;
+use syn::LitInt;
 use syn::PathArguments;
 use syn::ReturnType;
 use syn::Type;
@@ -158,7 +162,7 @@ fn match_trait_object(
         match bound {
             TypeParamBound::Trait(trait_) => {
                 out.push(t.bounds.to_token_stream());
-                if trait_.path.is_ident("_T") {
+                if trait_.path.is_ident("__") {
                     return true;
                 }
             }
@@ -218,9 +222,51 @@ pub fn pattern_match_type(pattern: &Type, ty: &Type, out: &mut Vec<TokenStream>)
     }
 }
 
+pub fn replace(matches: &[TokenStream], stream: TokenStream) -> TokenStream {
+    let mut out = TokenStream::new();
+    let mut stream = stream.into_iter().peekable();
+    while let Some(t) = stream.next() {
+        let t = match t {
+            TokenTree::Group(g) => {
+                let stream = replace(matches, g.stream());
+                let mut t = Group::new(g.delimiter(), stream);
+                t.set_span(g.span());
+
+                TokenTree::Group(t)
+            }
+            TokenTree::Ident(_) => t,
+            TokenTree::Punct(ref p) if p.as_char() == '#' => {
+                if let Some(l) = stream.next_if(|t| {
+                    matches!(t, TokenTree::Literal(l) if {
+                        // This hurts...
+                        // TODO: figure out a better way to match integer literals
+                        syn::parse2::<LitInt>(l.into_token_stream()).is_ok()
+                    })
+                }) {
+                    let TokenTree::Literal(l) = l else {
+                        unreachable!("Checked Above");
+                    };
+                    let n = syn::parse2::<LitInt>(l.into_token_stream()).expect("checked above");
+                    matches[n.base10_parse::<usize>().unwrap()].to_tokens(&mut out);
+                    continue;
+                } else {
+                    t
+                }
+            }
+            TokenTree::Punct(_) => t,
+            TokenTree::Literal(_) => t,
+        };
+        out.append(t);
+    }
+    out
+}
+
 #[cfg(test)]
 mod test {
+    use quote::quote;
     use syn::{Type, parse_quote};
+
+    use crate::util::pattern::replace;
 
     use super::pattern_match_type;
 
@@ -454,12 +500,12 @@ mod test {
     #[test]
     fn trait_object() {
         match_pattern! {
-            dyn _T =>
+            dyn __ =>
                 dyn Foo       => Foo;
                 dyn Foo + Bar => Foo + Bar;
         }
         match_pattern! {
-            dyn _T => !
+            dyn __ => !
                 [u32; 3],
                 fn(u32, u8) -> String,
                 my_macro!(12),
@@ -498,7 +544,7 @@ mod test {
                 (u8, u32) => u8, u32;
         }
         match_pattern! {
-            dyn _T => !
+            dyn __ => !
                 [u32; 3],
                 fn(u32, u8) -> String,
                 my_macro!(12),
@@ -507,5 +553,44 @@ mod test {
                 &dyn Foo,
                 (u8, u32, String),
         };
+    }
+
+    macro_rules! test_replace {
+        ([$({$($matches: tt)*}),*$(,)?] + { $($tt: tt)* } => $($out: tt)*) => {
+            eprintln!("{} + {} => {}", stringify!([$({$($matches)*}),*]), stringify!($($tt)*), stringify!($($out)*));
+            let x = replace(&[$(quote! { $($matches)* }),*], quote! { $($tt)* });
+            assert_eq!(x.to_string(), quote! { $($out)* }.to_string());
+        };
+    }
+
+    #[test]
+    fn replace_() {
+        test_replace! {
+            [{ foo }] + { Foo<#0> } => Foo<foo>
+        };
+        test_replace! {
+            [{ foo }, { bar }] + { Foo<#0, #1> } => Foo<foo, bar>
+        };
+    }
+
+    #[test]
+    fn roundtrip() {
+        let mut out = Vec::new();
+        let matches = pattern_match_type(
+            &parse_quote! { HashMap<_, _> },
+            &parse_quote! { HashMap<String, Value> },
+            &mut out,
+        );
+        assert!(matches);
+
+        let out = replace(
+            &out,
+            quote! { repeat = (#0, #1), adapter = |name: impl Into<#0>, value: Value| (name.into(), value) },
+        );
+        dbg!(out.to_string());
+        assert_eq!(
+            out.to_string(),
+            quote! {  repeat = (String, Value), adapter = |name: impl Into<String>, value: Value| (name.into(), value)  }.to_string()
+        );
     }
 }

--- a/bauer-macros/src/util/pattern.rs
+++ b/bauer-macros/src/util/pattern.rs
@@ -1,0 +1,511 @@
+use proc_macro2::TokenStream;
+use quote::ToTokens;
+use syn::Expr;
+use syn::GenericArgument;
+use syn::PathArguments;
+use syn::ReturnType;
+use syn::Type;
+use syn::TypeArray;
+use syn::TypeBareFn;
+use syn::TypeParamBound;
+use syn::TypePath;
+use syn::TypeTraitObject;
+use syn::TypeTuple;
+use syn::parse_quote;
+
+fn match_arrays(pattern: &TypeArray, ty: &TypeArray, out: &mut Vec<TokenStream>) -> bool {
+    if pattern == ty {
+        true
+    } else if let Expr::Infer(_) = pattern.len {
+        let ret = pattern_match_type(&pattern.elem, &ty.elem, out);
+        out.push(ty.len.to_token_stream());
+        ret
+    } else if ty.len == pattern.len {
+        pattern_match_type(&pattern.elem, &ty.elem, out)
+    } else {
+        false
+    }
+}
+
+fn match_bare_function(pattern: &TypeBareFn, ty: &TypeBareFn, out: &mut Vec<TokenStream>) -> bool {
+    if pattern == ty {
+        return true;
+    }
+
+    if ty.inputs.len() != pattern.inputs.len() {
+        return false;
+    }
+
+    for (f, p) in ty.inputs.iter().zip(pattern.inputs.iter()) {
+        if !pattern_match_type(&p.ty, &f.ty, out) {
+            return false;
+        }
+    }
+
+    match (&ty.output, &pattern.output) {
+        (ReturnType::Default, ReturnType::Default) => true,
+        (ReturnType::Default, ReturnType::Type(_, ty)) => {
+            pattern_match_type(ty, &parse_quote! { () }, out)
+        }
+        (ReturnType::Type(_, _), ReturnType::Default) => false,
+        (ReturnType::Type(_, f), ReturnType::Type(_, p)) => pattern_match_type(p, f, out),
+    }
+}
+
+fn match_path(pattern: &TypePath, ty: &TypePath, out: &mut Vec<TokenStream>) -> bool {
+    if pattern == ty {
+        return true;
+    }
+
+    if ty.path.segments.len() != pattern.path.segments.len() {
+        return false;
+    }
+
+    for (t_seg, p_seg) in ty.path.segments.iter().zip(pattern.path.segments.iter()) {
+        if t_seg.arguments.is_empty() != p_seg.arguments.is_empty() {
+            return false;
+        }
+
+        match (&t_seg.arguments, &p_seg.arguments) {
+            (PathArguments::None, PathArguments::None)
+            | (PathArguments::None, PathArguments::AngleBracketed(_))
+            | (PathArguments::None, PathArguments::Parenthesized(_))
+            | (PathArguments::AngleBracketed(_), PathArguments::None)
+            | (PathArguments::AngleBracketed(_), PathArguments::Parenthesized(_))
+            | (PathArguments::Parenthesized(_), PathArguments::None)
+            | (PathArguments::Parenthesized(_), PathArguments::AngleBracketed(_)) => {
+                return false;
+            }
+            (PathArguments::AngleBracketed(t), PathArguments::AngleBracketed(p)) => {
+                if t.args.len() != p.args.len() {
+                    return false;
+                }
+
+                for (t, p) in t.args.iter().zip(p.args.iter()) {
+                    match (t, p) {
+                        (GenericArgument::Lifetime(tl), GenericArgument::Lifetime(pl)) => {
+                            if tl != pl {
+                                return false;
+                            }
+                        }
+                        (
+                            GenericArgument::Lifetime(lifetime),
+                            GenericArgument::Type(Type::Infer(_)),
+                        ) => {
+                            out.push(lifetime.to_token_stream());
+                        }
+                        (GenericArgument::Lifetime(_), _) => return false,
+                        (GenericArgument::Type(t_ty), GenericArgument::Type(p_ty)) => {
+                            if !pattern_match_type(p_ty, t_ty, out) {
+                                return false;
+                            }
+                        }
+                        (GenericArgument::Type(_), _) => return false,
+                        (GenericArgument::Const(expr), GenericArgument::Type(Type::Infer(_))) => {
+                            out.push(expr.to_token_stream());
+                        }
+                        (GenericArgument::Const(_), _) => return false,
+                        (GenericArgument::AssocType(_), _)
+                        | (GenericArgument::AssocConst(_), _)
+                        | (GenericArgument::Constraint(_), _) => unreachable!(),
+                        _ => todo!(),
+                    }
+                }
+            }
+            (PathArguments::Parenthesized(t), PathArguments::Parenthesized(p)) => {
+                if t.inputs.len() != p.inputs.len() {
+                    return false;
+                }
+
+                for (f, p) in t.inputs.iter().zip(p.inputs.iter()) {
+                    if !pattern_match_type(p, f, out) {
+                        return false;
+                    }
+                }
+
+                let out_matched = match (&t.output, &p.output) {
+                    (ReturnType::Default, ReturnType::Default) => true,
+                    (ReturnType::Default, ReturnType::Type(_, ty)) => {
+                        pattern_match_type(ty, &parse_quote! { () }, out)
+                    }
+                    (ReturnType::Type(_, _), ReturnType::Default) => false,
+                    (ReturnType::Type(_, f), ReturnType::Type(_, p)) => {
+                        pattern_match_type(p, f, out)
+                    }
+                };
+
+                if !out_matched {
+                    return false;
+                }
+            }
+        };
+    }
+
+    true
+}
+
+fn match_trait_object(
+    p: &TypeTraitObject,
+    t: &TypeTraitObject,
+    out: &mut Vec<TokenStream>,
+) -> bool {
+    if p == t {
+        return true;
+    }
+
+    if p.bounds.len() == 1 {
+        let bound = p.bounds.iter().next().expect("checked");
+        match bound {
+            TypeParamBound::Trait(trait_) => {
+                out.push(t.bounds.to_token_stream());
+                if trait_.path.is_ident("_T") {
+                    return true;
+                }
+            }
+            _ => return false,
+        }
+    }
+    false
+}
+
+fn match_tuple(pattern: &TypeTuple, ty: &TypeTuple, out: &mut Vec<TokenStream>) -> bool {
+    if pattern == ty {
+        return true;
+    }
+
+    if ty.elems.len() != pattern.elems.len() {
+        return false;
+    }
+
+    for (t, p) in ty.elems.iter().zip(pattern.elems.iter()) {
+        if !pattern_match_type(p, t, out) {
+            return false;
+        }
+    }
+
+    true
+}
+
+pub fn pattern_match_type(pattern: &Type, ty: &Type, out: &mut Vec<TokenStream>) -> bool {
+    if pattern == ty {
+        return true;
+    };
+
+    if let Type::Infer(_) = pattern {
+        out.push(ty.to_token_stream());
+        return true;
+    }
+
+    match (ty, pattern) {
+        (Type::Array(arr), Type::Array(pat)) => match_arrays(pat, arr, out),
+        (Type::BareFn(func), Type::BareFn(pat)) => match_bare_function(pat, func, out),
+        (Type::Group(t), Type::Group(p)) => pattern_match_type(&p.elem, &t.elem, out),
+        (Type::Macro(t), Type::Macro(p)) => t == p,
+        (Type::Ptr(t), Type::Ptr(p)) => {
+            t.mutability == p.mutability && pattern_match_type(&p.elem, &t.elem, out)
+        }
+        (Type::Never(_), Type::Never(_)) => true,
+        (Type::Paren(t), Type::Paren(p)) => pattern_match_type(&p.elem, &t.elem, out),
+        (Type::Path(t), Type::Path(p)) => match_path(p, t, out),
+        (Type::Reference(t), Type::Reference(p)) => pattern_match_type(&p.elem, &t.elem, out),
+        (Type::Slice(t), Type::Slice(p)) => pattern_match_type(&p.elem, &t.elem, out),
+        (Type::TraitObject(t), Type::TraitObject(p)) => match_trait_object(p, t, out),
+        (Type::Tuple(t), Type::Tuple(p)) => match_tuple(p, t, out),
+        (Type::ImplTrait(_), Type::ImplTrait(_)) => unreachable!("Not allowed in this position"),
+        (Type::Infer(_), Type::Infer(_)) => unreachable!("Not allowed in this position"),
+        (Type::Verbatim(_), Type::Verbatim(_)) => unreachable!(),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use syn::{Type, parse_quote};
+
+    use super::pattern_match_type;
+
+    macro_rules! match_pattern {
+        ($pat: ty => $($ty: ty => $($match: ty),*;)*) => {
+            let pattern: Type = parse_quote! { $pat };
+
+            let mut out = Vec::new();
+
+            $(
+                out.clear();
+                let ty: Type = parse_quote! { $ty };
+                let matches = pattern_match_type(&pattern, &ty, &mut out);
+
+                for (i, m) in out.iter().enumerate() {
+                    eprintln!("out[{}] = {}", i, m);
+                }
+                assert!(matches);
+
+                $(
+                    eprintln!("~= {}", stringify!($ty));
+                    let ty: Type = syn::parse2(out.remove(0)).unwrap();
+                    let inner: Type = parse_quote! { $match };
+                    assert_eq!(ty, inner);
+                )*
+                assert!(out.is_empty(), "more matches than expected");
+            )*
+        };
+        ($pat: ty => ! $($ty: ty),*$(,)?) => {
+            let pattern: Type = parse_quote! { $pat };
+
+            let mut out = Vec::new();
+
+            $(
+                out.clear();
+                let ty: Type = parse_quote! { $ty };
+                let matches = pattern_match_type(&pattern, &ty, &mut out);
+
+                eprintln!("!= {}", stringify!($ty));
+                for (i, m) in out.iter().enumerate() {
+                    eprintln!("out[{}] = {}", i, m);
+                }
+                assert!(!matches);
+            )*
+        };
+    }
+
+    #[test]
+    fn blanket() {
+        match_pattern! {
+            _ =>
+                [u32; 3]              => [u32; 3];
+                fn(u32, u8) -> String => fn(u32, u8) -> String;
+                my_macro!(12)         => my_macro!(12);
+                *const String         => *const String;
+                (Vec<u32>)            => (Vec<u32>);
+                Vec<u32>              => Vec<u32>;
+                &dyn Foo              => &dyn Foo;
+                (u32, u8)             => (u32, u8);
+        };
+    }
+
+    #[test]
+    fn vec_underscore() {
+        match_pattern! {
+            Vec<_> =>
+                Vec<u32>              => u32;
+        }
+        match_pattern! {
+            Vec<_> => !
+                [u32; 3],
+                fn(u32, u8) -> String,
+                my_macro!(12),
+                *const String,
+                (Vec<u32>),
+                &dyn Foo,
+                (u32, u8),
+        };
+    }
+
+    #[test]
+    fn arrays() {
+        match_pattern! {
+            [_; 3] =>
+                [u32; 3]    => u32;
+                [String; 3] => String;
+        }
+        match_pattern! {
+            [_; 3] => !
+                [u32; 4],
+                fn(u32, u8) -> String,
+                my_macro!(12),
+                *const String,
+                (Vec<u32>),
+                &dyn Foo,
+                (u32, u8),
+        };
+    }
+
+    #[test]
+    fn bare_fn_arg() {
+        match_pattern! {
+            fn(_) -> u32 =>
+                fn(u64) -> u32    => u64;
+                fn(String) -> u32 => String;
+        }
+        match_pattern! {
+            fn(_) -> u32 => !
+                [u32; 4],
+                my_macro!(12),
+                *const String,
+                (Vec<u32>),
+                &dyn Foo,
+                (u32, u8),
+        };
+    }
+
+    #[test]
+    fn bare_fn_output() {
+        match_pattern! {
+            fn(u32) -> _ =>
+                fn(u32) -> u64    => u64;
+                fn(u32) -> String => String;
+        }
+        match_pattern! {
+            fn(u32) -> _ => !
+                [u32; 4],
+                my_macro!(12),
+                *const String,
+                (Vec<u32>),
+                &dyn Foo,
+                (u32, u8),
+        };
+    }
+
+    #[test]
+    fn pointers() {
+        match_pattern! {
+            *const _ =>
+                *const String    => String;
+                *const *const u8 => *const u8;
+                *const *mut u8   => *mut u8;
+        }
+        match_pattern! {
+            *const _ => !
+                [u32; 3],
+                fn(u32, u8) -> String,
+                my_macro!(12),
+                *mut String,
+                (Vec<u32>),
+                &dyn Foo,
+                (u32, u8),
+        };
+    }
+
+    #[test]
+    fn paren() {
+        match_pattern! {
+            (_) =>
+                ([u32; 3])              => [u32; 3];
+                (fn(u32, u8) -> String) => fn(u32, u8) -> String;
+                (my_macro!(12))         => my_macro!(12);
+                (*const String)         => *const String;
+                ((Vec<u32>))            => (Vec<u32>);
+                (Vec<u32>)              => Vec<u32>;
+                (&dyn Foo)              => &dyn Foo;
+                ((u32, u8))             => (u32, u8);
+        }
+        match_pattern! {
+            (_) => !
+                [u32; 3],
+                fn(u32, u8) -> String,
+                my_macro!(12),
+                *const String,
+                Vec<u32>,
+                &dyn Foo,
+                (u32, u8),
+        };
+    }
+
+    #[test]
+    fn reference() {
+        match_pattern! {
+            &_ =>
+                &[u32; 3]              => [u32; 3];
+                &fn(u32, u8) -> String => fn(u32, u8) -> String;
+                &my_macro!(12)         => my_macro!(12);
+                &*const String         => *const String;
+                &(Vec<u32>)            => (Vec<u32>);
+                &Vec<u32>              => Vec<u32>;
+                &dyn Foo               => dyn Foo;
+                &(u32, u8)             => (u32, u8);
+        }
+        match_pattern! {
+            &_ => !
+                [u32; 3],
+                fn(u32, u8) -> String,
+                my_macro!(12),
+                *const String,
+                Vec<u32>,
+                dyn Foo,
+                (u32, u8),
+        };
+    }
+
+    #[test]
+    fn slice() {
+        match_pattern! {
+            [_] =>
+                [[u32; 3]]              => [u32; 3];
+                [fn(u32, u8) -> String] => fn(u32, u8) -> String;
+                [my_macro!(12)]         => my_macro!(12);
+                [*const String]         => *const String;
+                [(Vec<u32>)]            => (Vec<u32>);
+                [Vec<u32>]              => Vec<u32>;
+                [dyn Foo]               => dyn Foo;
+                [(u32, u8)]             => (u32, u8);
+        }
+        match_pattern! {
+            [_] => !
+                [u32; 3],
+                fn(u32, u8) -> String,
+                my_macro!(12),
+                *const String,
+                Vec<u32>,
+                dyn Foo,
+                (u32, u8),
+        };
+    }
+
+    #[test]
+    fn trait_object() {
+        match_pattern! {
+            dyn _T =>
+                dyn Foo       => Foo;
+                dyn Foo + Bar => Foo + Bar;
+        }
+        match_pattern! {
+            dyn _T => !
+                [u32; 3],
+                fn(u32, u8) -> String,
+                my_macro!(12),
+                *const String,
+                Vec<u32>,
+                &dyn Foo,
+                (u32, u8),
+        };
+    }
+
+    #[test]
+    fn tuple_single() {
+        match_pattern! {
+            (_, u32) =>
+                (String, u32) => String;
+                (u8, u32) => u8;
+        }
+        match_pattern! {
+            dyn _T => !
+                [u32; 3],
+                fn(u32, u8) -> String,
+                my_macro!(12),
+                *const String,
+                Vec<u32>,
+                &dyn Foo,
+                (u8, u8),
+                (u8, u32, String),
+        };
+    }
+
+    #[test]
+    fn tuple_multiple() {
+        match_pattern! {
+            (_, _) =>
+                (String, u32) => String, u32;
+                (u8, u32) => u8, u32;
+        }
+        match_pattern! {
+            dyn _T => !
+                [u32; 3],
+                fn(u32, u8) -> String,
+                my_macro!(12),
+                *const String,
+                Vec<u32>,
+                &dyn Foo,
+                (u8, u32, String),
+        };
+    }
+}

--- a/bauer-macros/src/util/pattern.rs
+++ b/bauer-macros/src/util/pattern.rs
@@ -212,7 +212,9 @@ pub fn pattern_match_type(pattern: &Type, ty: &Type, out: &mut Vec<TokenStream>)
         (Type::Never(_), Type::Never(_)) => true,
         (Type::Paren(t), Type::Paren(p)) => pattern_match_type(&p.elem, &t.elem, out),
         (Type::Path(t), Type::Path(p)) => match_path(p, t, out),
-        (Type::Reference(t), Type::Reference(p)) => pattern_match_type(&p.elem, &t.elem, out),
+        (Type::Reference(t), Type::Reference(p)) => {
+            t.mutability == p.mutability && pattern_match_type(&p.elem, &t.elem, out)
+        }
         (Type::Slice(t), Type::Slice(p)) => pattern_match_type(&p.elem, &t.elem, out),
         (Type::TraitObject(t), Type::TraitObject(p)) => match_trait_object(p, t, out),
         (Type::Tuple(t), Type::Tuple(p)) => match_tuple(p, t, out),

--- a/bauer-macros/src/util/pattern.rs
+++ b/bauer-macros/src/util/pattern.rs
@@ -18,21 +18,25 @@ use syn::TypeTraitObject;
 use syn::TypeTuple;
 use syn::parse_quote;
 
-fn match_arrays(pattern: &TypeArray, ty: &TypeArray, out: &mut Vec<TokenStream>) -> bool {
+fn match_arrays(pattern: &TypeArray, ty: &TypeArray, matches: &mut Vec<TokenStream>) -> bool {
     if pattern == ty {
         true
     } else if let Expr::Infer(_) = pattern.len {
-        let ret = pattern_match_type(&pattern.elem, &ty.elem, out);
-        out.push(ty.len.to_token_stream());
+        let ret = pattern_match_type_inner(&pattern.elem, &ty.elem, matches);
+        matches.push(ty.len.to_token_stream());
         ret
     } else if ty.len == pattern.len {
-        pattern_match_type(&pattern.elem, &ty.elem, out)
+        pattern_match_type_inner(&pattern.elem, &ty.elem, matches)
     } else {
         false
     }
 }
 
-fn match_bare_function(pattern: &TypeBareFn, ty: &TypeBareFn, out: &mut Vec<TokenStream>) -> bool {
+fn match_bare_function(
+    pattern: &TypeBareFn,
+    ty: &TypeBareFn,
+    matches: &mut Vec<TokenStream>,
+) -> bool {
     if pattern == ty {
         return true;
     }
@@ -42,7 +46,7 @@ fn match_bare_function(pattern: &TypeBareFn, ty: &TypeBareFn, out: &mut Vec<Toke
     }
 
     for (f, p) in ty.inputs.iter().zip(pattern.inputs.iter()) {
-        if !pattern_match_type(&p.ty, &f.ty, out) {
+        if !pattern_match_type_inner(&p.ty, &f.ty, matches) {
             return false;
         }
     }
@@ -50,14 +54,14 @@ fn match_bare_function(pattern: &TypeBareFn, ty: &TypeBareFn, out: &mut Vec<Toke
     match (&ty.output, &pattern.output) {
         (ReturnType::Default, ReturnType::Default) => true,
         (ReturnType::Default, ReturnType::Type(_, ty)) => {
-            pattern_match_type(ty, &parse_quote! { () }, out)
+            pattern_match_type_inner(ty, &parse_quote! { () }, matches)
         }
         (ReturnType::Type(_, _), ReturnType::Default) => false,
-        (ReturnType::Type(_, f), ReturnType::Type(_, p)) => pattern_match_type(p, f, out),
+        (ReturnType::Type(_, f), ReturnType::Type(_, p)) => pattern_match_type_inner(p, f, matches),
     }
 }
 
-fn match_path(pattern: &TypePath, ty: &TypePath, out: &mut Vec<TokenStream>) -> bool {
+fn match_path(pattern: &TypePath, ty: &TypePath, matches: &mut Vec<TokenStream>) -> bool {
     if pattern == ty {
         return true;
     }
@@ -72,48 +76,34 @@ fn match_path(pattern: &TypePath, ty: &TypePath, out: &mut Vec<TokenStream>) -> 
         }
 
         match (&t_seg.arguments, &p_seg.arguments) {
-            (PathArguments::None, PathArguments::None)
-            | (PathArguments::None, PathArguments::AngleBracketed(_))
-            | (PathArguments::None, PathArguments::Parenthesized(_))
-            | (PathArguments::AngleBracketed(_), PathArguments::None)
-            | (PathArguments::AngleBracketed(_), PathArguments::Parenthesized(_))
-            | (PathArguments::Parenthesized(_), PathArguments::None)
-            | (PathArguments::Parenthesized(_), PathArguments::AngleBracketed(_)) => {
-                return false;
-            }
             (PathArguments::AngleBracketed(t), PathArguments::AngleBracketed(p)) => {
                 if t.args.len() != p.args.len() {
                     return false;
                 }
 
                 for (t, p) in t.args.iter().zip(p.args.iter()) {
+                    use GenericArgument::{Const, Lifetime, Type as GenType};
                     match (t, p) {
-                        (GenericArgument::Lifetime(tl), GenericArgument::Lifetime(pl)) => {
+                        (Lifetime(tl), Lifetime(pl)) => {
                             if tl != pl {
                                 return false;
                             }
                         }
-                        (
-                            GenericArgument::Lifetime(lifetime),
-                            GenericArgument::Type(Type::Infer(_)),
-                        ) => {
-                            out.push(lifetime.to_token_stream());
+                        (Lifetime(lifetime), GenType(Type::Infer(_))) => {
+                            matches.push(lifetime.to_token_stream());
                         }
-                        (GenericArgument::Lifetime(_), _) => return false,
-                        (GenericArgument::Type(t_ty), GenericArgument::Type(p_ty)) => {
-                            if !pattern_match_type(p_ty, t_ty, out) {
+                        (Lifetime(_), _) => return false,
+                        (GenType(t_ty), GenType(p_ty)) => {
+                            if !pattern_match_type_inner(p_ty, t_ty, matches) {
                                 return false;
                             }
                         }
-                        (GenericArgument::Type(_), _) => return false,
-                        (GenericArgument::Const(expr), GenericArgument::Type(Type::Infer(_))) => {
-                            out.push(expr.to_token_stream());
+                        (GenType(_), _) => return false,
+                        (Const(expr), GenType(Type::Infer(_))) => {
+                            matches.push(expr.to_token_stream());
                         }
-                        (GenericArgument::Const(_), _) => return false,
-                        (GenericArgument::AssocType(_), _)
-                        | (GenericArgument::AssocConst(_), _)
-                        | (GenericArgument::Constraint(_), _) => unreachable!(),
-                        _ => todo!(),
+                        (Const(_), _) => return false,
+                        _ => return false,
                     }
                 }
             }
@@ -123,7 +113,7 @@ fn match_path(pattern: &TypePath, ty: &TypePath, out: &mut Vec<TokenStream>) -> 
                 }
 
                 for (f, p) in t.inputs.iter().zip(p.inputs.iter()) {
-                    if !pattern_match_type(p, f, out) {
+                    if !pattern_match_type_inner(p, f, matches) {
                         return false;
                     }
                 }
@@ -131,11 +121,11 @@ fn match_path(pattern: &TypePath, ty: &TypePath, out: &mut Vec<TokenStream>) -> 
                 let out_matched = match (&t.output, &p.output) {
                     (ReturnType::Default, ReturnType::Default) => true,
                     (ReturnType::Default, ReturnType::Type(_, ty)) => {
-                        pattern_match_type(ty, &parse_quote! { () }, out)
+                        pattern_match_type_inner(ty, &parse_quote! { () }, matches)
                     }
                     (ReturnType::Type(_, _), ReturnType::Default) => false,
                     (ReturnType::Type(_, f), ReturnType::Type(_, p)) => {
-                        pattern_match_type(p, f, out)
+                        pattern_match_type_inner(p, f, matches)
                     }
                 };
 
@@ -143,6 +133,7 @@ fn match_path(pattern: &TypePath, ty: &TypePath, out: &mut Vec<TokenStream>) -> 
                     return false;
                 }
             }
+            _ => return false,
         };
     }
 
@@ -152,7 +143,7 @@ fn match_path(pattern: &TypePath, ty: &TypePath, out: &mut Vec<TokenStream>) -> 
 fn match_trait_object(
     p: &TypeTraitObject,
     t: &TypeTraitObject,
-    out: &mut Vec<TokenStream>,
+    matches: &mut Vec<TokenStream>,
 ) -> bool {
     if p == t {
         return true;
@@ -162,7 +153,7 @@ fn match_trait_object(
         let bound = p.bounds.iter().next().expect("checked");
         match bound {
             TypeParamBound::Trait(trait_) => {
-                out.push(t.bounds.to_token_stream());
+                matches.push(t.bounds.to_token_stream());
                 if trait_.path.is_ident("__") {
                     return true;
                 }
@@ -173,7 +164,7 @@ fn match_trait_object(
     false
 }
 
-fn match_tuple(pattern: &TypeTuple, ty: &TypeTuple, out: &mut Vec<TokenStream>) -> bool {
+fn match_tuple(pattern: &TypeTuple, ty: &TypeTuple, matches: &mut Vec<TokenStream>) -> bool {
     if pattern == ty {
         return true;
     }
@@ -183,7 +174,7 @@ fn match_tuple(pattern: &TypeTuple, ty: &TypeTuple, out: &mut Vec<TokenStream>) 
     }
 
     for (t, p) in ty.elems.iter().zip(pattern.elems.iter()) {
-        if !pattern_match_type(p, t, out) {
+        if !pattern_match_type_inner(p, t, matches) {
             return false;
         }
     }
@@ -191,37 +182,46 @@ fn match_tuple(pattern: &TypeTuple, ty: &TypeTuple, out: &mut Vec<TokenStream>) 
     true
 }
 
-pub fn pattern_match_type(pattern: &Type, ty: &Type, out: &mut Vec<TokenStream>) -> bool {
+fn pattern_match_type_inner(pattern: &Type, ty: &Type, matches: &mut Vec<TokenStream>) -> bool {
     if pattern == ty {
         return true;
     };
 
     if let Type::Infer(_) = pattern {
-        out.push(ty.to_token_stream());
+        matches.push(ty.to_token_stream());
         return true;
     }
 
     match (ty, pattern) {
-        (Type::Array(arr), Type::Array(pat)) => match_arrays(pat, arr, out),
-        (Type::BareFn(func), Type::BareFn(pat)) => match_bare_function(pat, func, out),
-        (Type::Group(t), Type::Group(p)) => pattern_match_type(&p.elem, &t.elem, out),
+        (Type::Array(arr), Type::Array(pat)) => match_arrays(pat, arr, matches),
+        (Type::BareFn(func), Type::BareFn(pat)) => match_bare_function(pat, func, matches),
+        (Type::Group(t), Type::Group(p)) => pattern_match_type_inner(&p.elem, &t.elem, matches),
         (Type::Macro(t), Type::Macro(p)) => t == p,
         (Type::Ptr(t), Type::Ptr(p)) => {
-            t.mutability == p.mutability && pattern_match_type(&p.elem, &t.elem, out)
+            t.mutability == p.mutability && pattern_match_type_inner(&p.elem, &t.elem, matches)
         }
         (Type::Never(_), Type::Never(_)) => true,
-        (Type::Paren(t), Type::Paren(p)) => pattern_match_type(&p.elem, &t.elem, out),
-        (Type::Path(t), Type::Path(p)) => match_path(p, t, out),
+        (Type::Paren(t), Type::Paren(p)) => pattern_match_type_inner(&p.elem, &t.elem, matches),
+        (Type::Path(t), Type::Path(p)) => match_path(p, t, matches),
         (Type::Reference(t), Type::Reference(p)) => {
-            t.mutability == p.mutability && pattern_match_type(&p.elem, &t.elem, out)
+            t.mutability == p.mutability && pattern_match_type_inner(&p.elem, &t.elem, matches)
         }
-        (Type::Slice(t), Type::Slice(p)) => pattern_match_type(&p.elem, &t.elem, out),
-        (Type::TraitObject(t), Type::TraitObject(p)) => match_trait_object(p, t, out),
-        (Type::Tuple(t), Type::Tuple(p)) => match_tuple(p, t, out),
+        (Type::Slice(t), Type::Slice(p)) => pattern_match_type_inner(&p.elem, &t.elem, matches),
+        (Type::TraitObject(t), Type::TraitObject(p)) => match_trait_object(p, t, matches),
+        (Type::Tuple(t), Type::Tuple(p)) => match_tuple(p, t, matches),
         (Type::ImplTrait(_), Type::ImplTrait(_)) => unreachable!("Not allowed in this position"),
         (Type::Infer(_), Type::Infer(_)) => unreachable!("Not allowed in this position"),
         (Type::Verbatim(_), Type::Verbatim(_)) => unreachable!(),
         _ => false,
+    }
+}
+
+pub fn pattern_match_type(pattern: &Type, ty: &Type) -> Option<Vec<TokenStream>> {
+    let mut matches = Vec::new();
+    if pattern_match_type_inner(pattern, ty, &mut matches) {
+        Some(matches)
+    } else {
+        None
     }
 }
 
@@ -292,42 +292,32 @@ mod test {
         ($pat: ty => $($ty: ty => $($match: ty),*;)*) => {
             let pattern: Type = parse_quote! { $pat };
 
-            let mut out = Vec::new();
-
             $(
-                out.clear();
                 let ty: Type = parse_quote! { $ty };
-                let matches = pattern_match_type(&pattern, &ty, &mut out);
+                let mut matches = pattern_match_type(&pattern, &ty).unwrap();
 
-                for (i, m) in out.iter().enumerate() {
-                    eprintln!("out[{}] = {}", i, m);
+                for (i, m) in matches.iter().enumerate() {
+                    eprintln!("matches[{}] = {}", i, m);
                 }
-                assert!(matches);
 
                 $(
                     eprintln!("~= {}", stringify!($ty));
-                    let ty: Type = syn::parse2(out.remove(0)).unwrap();
+                    let ty: Type = syn::parse2(matches.remove(0)).unwrap();
                     let inner: Type = parse_quote! { $match };
                     assert_eq!(ty, inner);
                 )*
-                assert!(out.is_empty(), "more matches than expected");
+                assert!(matches.is_empty(), "more matches than expected");
             )*
         };
         ($pat: ty => ! $($ty: ty),*$(,)?) => {
             let pattern: Type = parse_quote! { $pat };
 
-            let mut out = Vec::new();
-
             $(
-                out.clear();
                 let ty: Type = parse_quote! { $ty };
-                let matches = pattern_match_type(&pattern, &ty, &mut out);
+                let matches = pattern_match_type(&pattern, &ty);
 
                 eprintln!("!= {}", stringify!($ty));
-                for (i, m) in out.iter().enumerate() {
-                    eprintln!("out[{}] = {}", i, m);
-                }
-                assert!(!matches);
+                assert!(matches.is_none());
             )*
         };
     }
@@ -593,19 +583,19 @@ mod test {
 
     #[test]
     fn roundtrip() {
-        let mut out = Vec::new();
         let matches = pattern_match_type(
             &parse_quote! { HashMap<_, _> },
             &parse_quote! { HashMap<String, Value> },
-            &mut out,
-        );
-        assert!(matches);
+        )
+        .unwrap();
 
         let out = replace(
-            &out,
+            &matches,
             quote! { repeat = (#0, #1), adapter = |name: impl Into<#0>, value: Value| (name.into(), value) },
         ).unwrap();
+
         dbg!(out.to_string());
+
         assert_eq!(
             out.to_string(),
             quote! {  repeat = (String, Value), adapter = |name: impl Into<String>, value: Value| (name.into(), value)  }.to_string()

--- a/bauer/examples/simple.rs
+++ b/bauer/examples/simple.rs
@@ -4,8 +4,10 @@ use bauer::Builder;
 
 #[derive(Debug, Builder)]
 #[builder(kind = "type-state", prefix = "set_")]
+#[builder(on(bool => default = "true"))]
+#[builder(on(_ => into))]
 pub struct Foo {
-    #[builder(default = "42")]
+    #[builder(default = "42u32")]
     field_a: u32,
     field_b: bool,
     #[builder(into)]
@@ -16,7 +18,7 @@ pub struct Foo {
 
 fn main() {
     let x: Foo = Foo::builder()
-        .set_field_a(69)
+        .set_field_a(69u32)
         .set_field_b(true)
         .set_field_c("hello world")
         .add_d(std::f64::consts::PI)

--- a/bauer/src/lib.rs
+++ b/bauer/src/lib.rs
@@ -71,6 +71,7 @@
 //! | [`build_fn`]                                 | Set details about the build function (`attributes`, `doc`, `rename`)                                        | `build_fn(...)`                              |
 //! | [`builder_fn`]                               | Set details about the builder function added to the struct (`attributes`, `doc`, `rename`)                  | `builder_fn(...)`                            |
 //! | [`error`]                                    | Set details about the generated error enum (`attributes`, `doc`, `rename`, `force`)                         | `error(...)`                                 |
+//! | [`on`]                                       | Apply field attributes to fields that match a specific type pattern                                         | `on(<type> => <attributes ...>)`             |
 //!
 //! [`kind`]: Builder#kind
 //! [`const`]: Builder#const
@@ -82,6 +83,7 @@
 //! [`build_fn`]: Builder#build_fn
 //! [`builder_fn`]: Builder#builder_fn
 //! [`error`]: Builder#error
+//! [`on`]: Builder#on
 //!
 //! ## Field Attributes
 //!
@@ -476,6 +478,56 @@
 ///     .field(3)
 ///     .build();
 /// # let _ = result;
+/// ```
+///
+/// ## **`on`**
+///
+/// Specify a set of [field attributes](#field-attributes) that should be applied to all fields that
+/// match a specific type.
+///
+/// Type matching is done by specifying a pattern that may contain `_` to represent a wildcard type.
+/// When a wildcard is matched, the result of the match is can be used in the attributes as
+/// `#<index>` (i.e., `#0`). Due to parsing reasons, a wildcard after `dyn` needs to be specified
+/// with `__`.
+///
+/// > ### **NOTE**
+/// >
+/// > _Due to how derive macros work, this type matching happens on the level of tokens.  So,
+/// > `Vec<_>` does _not_ match `std::vec::Vec<T>`.  This limitation applies to all parts of the
+/// > type, including generics, constants, etc._
+///
+/// ```
+/// # use bauer_macros::Builder;
+/// #[derive(Builder)]
+/// #[builder(on(Vec<_> => repeat))]
+/// pub struct Foo {
+///     field: Vec<u32>,
+/// }
+///
+/// let result: Foo = Foo::builder()
+///     .field(0)
+///     .field(1)
+///     .field(2)
+///     .build();
+/// ```
+///
+/// ```
+/// # use bauer_macros::Builder;
+/// # use std::collections::HashMap;
+/// #[derive(Builder)]
+/// #[builder(on(HashMap<_, _> => repeat = (#0, #1), tuple))]
+/// pub struct Foo {
+///     #[builder(into)]
+///     bar: HashMap<String, f64>,
+///     baz: HashMap<u32, f64>,
+/// }
+///
+/// let result: Foo = Foo::builder()
+///     .bar("pi", 3.14)
+///     .bar("tau", 6.28)
+///     .baz(0, 1.0)
+///     .baz(5, 63.4)
+///     .build();
 /// ```
 ///
 /// # Fields Attributes

--- a/bauer/tests/comprehensive-edge-cases.rs
+++ b/bauer/tests/comprehensive-edge-cases.rs
@@ -596,7 +596,6 @@ macro_rules! tests {
             fn test_maximum_generic_parameters() {
                 #[derive(Builder)]
                 #[builder(kind = $kind)]
-                #[builder(build_method = "construct")]
                 struct MaxGenerics<
                     'a,
                     'b,

--- a/bauer/tests/on.rs
+++ b/bauer/tests/on.rs
@@ -1,0 +1,193 @@
+#![allow(dead_code)]
+
+macro_rules! tests {
+    ($kind: literal in mod $module: ident $($unwrap: ident)?) => {
+        mod $module {
+
+            mod all_default {
+                use bauer::Builder;
+                use std::collections::HashMap;
+
+                #[derive(Debug, Builder, PartialEq)]
+                #[builder(kind = $kind, on(_ => default))]
+                struct Foo {
+                    u32: u32,
+                    vec: Vec<u32>,
+                    map: HashMap<u32, u32>,
+                }
+
+                #[test]
+                fn minimal() {
+                    let c = Foo::builder().build();
+
+                    assert_eq!(c.u32, 0);
+                    assert_eq!(c.vec, [0; 0]);
+                    assert_eq!(c.map, HashMap::new());
+                }
+
+                #[test]
+                fn full() {
+                    let c = Foo::builder()
+                        .u32(42)
+                        .vec(vec![123, 456])
+                        .map([(1, 2), (3, 4)].into())
+                        .build();
+
+                    assert_eq!(c.u32, 42);
+                    assert_eq!(c.vec, [123, 456]);
+                    assert_eq!(c.map, [(1, 2), (3, 4)].into());
+                }
+            }
+
+            mod vec_repeat {
+                use bauer::Builder;
+                use std::collections::HashMap;
+
+                #[derive(Debug, Builder, PartialEq)]
+                #[builder(kind = $kind, on(Vec<_> => repeat))]
+                struct Foo {
+                    #[builder(default)]
+                    u32: u32,
+                    vec: Vec<u32>,
+                    vec2: Vec<u32>,
+                    #[builder(default)]
+                    map: HashMap<u32, u32>,
+                }
+
+                #[test]
+                fn minimal() {
+                    let c = Foo::builder().build();
+
+                    assert_eq!(c.u32, 0);
+                    assert_eq!(c.vec, [0; 0]);
+                    assert_eq!(c.vec2, [0; 0]);
+                    assert_eq!(c.map, HashMap::new());
+                }
+
+                #[test]
+                fn full() {
+                    let c = Foo::builder()
+                        .u32(42)
+                        .vec(123)
+                        .vec(456)
+                        .vec2(789)
+                        .map([(1, 2), (3, 4)].into())
+                        .build();
+
+                    assert_eq!(c.u32, 42);
+                    assert_eq!(c.vec, [123, 456]);
+                    assert_eq!(c.vec2, [789]);
+                    assert_eq!(c.map, [(1, 2), (3, 4)].into());
+                }
+            }
+
+            mod vec_map_repeat {
+                use bauer::Builder;
+                use std::collections::HashMap;
+
+                #[derive(Debug, Builder, PartialEq)]
+                #[builder(kind = $kind, on(Vec<_> => repeat), on(HashMap<_, _> => repeat = (#0, #1), tuple))]
+                struct Foo {
+                    #[builder(default)]
+                    u32: u32,
+                    vec: Vec<u32>,
+                    map: HashMap<u32, u32>,
+                }
+
+                #[test]
+                fn minimal() {
+                    let c = Foo::builder().build();
+
+                    assert_eq!(c.u32, 0);
+                    assert_eq!(c.vec, [0; 0]);
+                    assert_eq!(c.map, HashMap::new());
+                }
+
+                #[test]
+                fn full() {
+                    let c = Foo::builder()
+                        .u32(42)
+                        .vec(123)
+                        .vec(456)
+                        .map(1, 2)
+                        .map(3, 4)
+                        .build();
+
+                    assert_eq!(c.u32, 42);
+                    assert_eq!(c.vec, [123, 456]);
+                    assert_eq!(c.map, [(1, 2), (3, 4)].into());
+                }
+            }
+
+            mod automatic_manual_tuple {
+                use bauer::Builder;
+
+                #[derive(Debug, Builder, PartialEq)]
+                #[builder(kind = $kind, on((_, _) => adapter = |a: #0, b: #1| (a, b)))]
+                struct Foo<'a> {
+                    foo: (u32, &'a str)
+                }
+
+                #[test]
+                fn test() {
+                    let c = Foo::builder()
+                        .foo(69, "hello")
+                        .build()
+                        $(.$unwrap())?;
+
+                    assert_eq!(c.foo, (69, "hello"));
+                }
+            }
+
+            mod empty {
+                use bauer::Builder;
+
+                #[derive(Debug, Builder, PartialEq)]
+                #[builder(kind = $kind, on(_ => ))]
+                struct Foo {
+                    x: u32
+                }
+
+                #[test]
+                fn test() {
+                    let c = Foo::builder()
+                        .x(69)
+                        .build()
+                        $(.$unwrap())?;
+
+                    assert_eq!(c.x, 69);
+                }
+            }
+
+            mod string_into {
+                use bauer::Builder;
+
+                #[derive(Debug, Builder, PartialEq)]
+                #[builder(kind = $kind, on(String => into))]
+                struct Foo {
+                    x: String,
+                    y: String,
+                    z: String,
+                }
+
+                #[test]
+                fn test() {
+                    let c = Foo::builder()
+                        .x("hello x")
+                        .y("hello y")
+                        .z("hello z")
+                        .build()
+                        $(.$unwrap())?;
+
+                    assert_eq!(c.x, "hello x");
+                    assert_eq!(c.y, "hello y");
+                    assert_eq!(c.z, "hello z");
+                }
+            }
+        }
+    };
+}
+
+tests!("borrowed" in mod borrowed unwrap);
+tests!("owned" in mod owned unwrap);
+tests!("type-state" in mod type_state);

--- a/bauer/tests/ui/collector-wrong-argument.fail.stderr
+++ b/bauer/tests/ui/collector-wrong-argument.fail.stderr
@@ -12,7 +12,7 @@ error[E0308]: mismatched types
 note: function defined here
   --> tests/ui/collector-wrong-argument.fail.rs:3:4
    |
- 3 | fn count(_wrong_argument: Vec<u8>) -> usize {
+3  | fn count(_wrong_argument: Vec<u8>) -> usize {
    |    ^^^^^ ------------------------
 
 error[E0308]: mismatched types
@@ -29,5 +29,5 @@ error[E0308]: mismatched types
 note: function defined here
   --> tests/ui/collector-wrong-argument.fail.rs:3:4
    |
- 3 | fn count(_wrong_argument: Vec<u8>) -> usize {
+3  | fn count(_wrong_argument: Vec<u8>) -> usize {
    |    ^^^^^ ------------------------

--- a/bauer/tests/ui/on-conflict.fail.rs
+++ b/bauer/tests/ui/on-conflict.fail.rs
@@ -1,0 +1,10 @@
+use bauer::Builder;
+
+#[derive(Builder)]
+#[builder(on(Vec<_> => repeat))]
+struct Foo {
+    #[builder(default)]
+    foo: Vec<u32>,
+}
+
+fn main() {}

--- a/bauer/tests/ui/on-conflict.fail.stderr
+++ b/bauer/tests/ui/on-conflict.fail.stderr
@@ -1,0 +1,5 @@
+error: `default` cannot be added with `repeat`
+ --> tests/ui/on-conflict.fail.rs:6:15
+  |
+6 |     #[builder(default)]
+  |               ^^^^^^^

--- a/bauer/tests/ui/on-index-oob.fail.rs
+++ b/bauer/tests/ui/on-index-oob.fail.rs
@@ -1,0 +1,9 @@
+use bauer::Builder;
+
+#[derive(Builder)]
+#[builder(on(Vec<_> => repeat = #1))]
+struct Foo {
+    foo: Vec<u32>,
+}
+
+fn main() {}

--- a/bauer/tests/ui/on-index-oob.fail.stderr
+++ b/bauer/tests/ui/on-index-oob.fail.stderr
@@ -1,0 +1,5 @@
+error: index out of bounds: there were 1 matches but the index is 1, if you intended a literal '#1', use '# #1'
+ --> tests/ui/on-index-oob.fail.rs:4:33
+  |
+4 | #[builder(on(Vec<_> => repeat = #1))]
+  |                                 ^^

--- a/bauer/tests/ui/on-invalid-attr.fail.rs
+++ b/bauer/tests/ui/on-invalid-attr.fail.rs
@@ -1,0 +1,9 @@
+use bauer::Builder;
+
+#[derive(Builder)]
+#[builder(on(_ => foo))]
+pub struct Foo {
+    field_a: u32,
+}
+
+fn main() {}

--- a/bauer/tests/ui/on-invalid-attr.fail.stderr
+++ b/bauer/tests/ui/on-invalid-attr.fail.stderr
@@ -1,0 +1,5 @@
+error: Unknown attribute 'foo'.  Valid attribute are: 'default, into, repeat, repeat_n, rename, skip_prefix, skip_suffix, tuple, adapter, attributes, doc, collector, skip'
+ --> tests/ui/on-invalid-attr.fail.rs:4:19
+  |
+4 | #[builder(on(_ => foo))]
+  |                   ^^^

--- a/bauer/tests/ui/skip-conficts.fail.stderr
+++ b/bauer/tests/ui/skip-conficts.fail.stderr
@@ -1,7 +1,7 @@
 error: `skip` may not be used with any other attributes
   --> tests/ui/skip-conficts.fail.rs:8:23
    |
- 8 |             #[builder(skip, $($tt)*)]
+8  |             #[builder(skip, $($tt)*)]
    |                       ^^^^
 ...
 24 | define!(BeforeDefault,    AfterDefault    as (       u32) => default                       );
@@ -23,7 +23,7 @@ error: `skip` may not be used with any other attributes
 error: `skip` may not be used with any other attributes
   --> tests/ui/skip-conficts.fail.rs:8:23
    |
- 8 |             #[builder(skip, $($tt)*)]
+8  |             #[builder(skip, $($tt)*)]
    |                       ^^^^
 ...
 25 | define!(BeforeRepeat,     AfterRepeat     as (  Vec<u32>) => repeat                        );
@@ -45,7 +45,7 @@ error: `skip` may not be used with any other attributes
 error: `skip` may not be used with any other attributes
   --> tests/ui/skip-conficts.fail.rs:8:23
    |
- 8 |             #[builder(skip, $($tt)*)]
+8  |             #[builder(skip, $($tt)*)]
    |                       ^^^^
 ...
 26 | define!(BeforeRepeatN,    AfterRepeatN    as (  Vec<u32>) => repeat, repeat_n = 2          );
@@ -67,7 +67,7 @@ error: `skip` may not be used with any other attributes
 error: `skip` may not be used with any other attributes
   --> tests/ui/skip-conficts.fail.rs:8:23
    |
- 8 |             #[builder(skip, $($tt)*)]
+8  |             #[builder(skip, $($tt)*)]
    |                       ^^^^
 ...
 27 | define!(BeforeCollector,  AfterCollector  as (       u32) => repeat = u32, collector = foo );
@@ -89,7 +89,7 @@ error: `skip` may not be used with any other attributes
 error: `skip` may not be used with any other attributes
   --> tests/ui/skip-conficts.fail.rs:8:23
    |
- 8 |             #[builder(skip, $($tt)*)]
+8  |             #[builder(skip, $($tt)*)]
    |                       ^^^^
 ...
 28 | define!(BeforeInto,       AfterInto       as (       u32) => into                          );
@@ -111,7 +111,7 @@ error: `skip` may not be used with any other attributes
 error: `skip` may not be used with any other attributes
   --> tests/ui/skip-conficts.fail.rs:8:23
    |
- 8 |             #[builder(skip, $($tt)*)]
+8  |             #[builder(skip, $($tt)*)]
    |                       ^^^^
 ...
 29 | define!(BeforeTuple,      AfterTuple      as ((u32, u32)) => tuple                         );
@@ -133,7 +133,7 @@ error: `skip` may not be used with any other attributes
 error: `skip` may not be used with any other attributes
   --> tests/ui/skip-conficts.fail.rs:8:23
    |
- 8 |             #[builder(skip, $($tt)*)]
+8  |             #[builder(skip, $($tt)*)]
    |                       ^^^^
 ...
 30 | define!(BeforeAdapter,    AfterAdapter    as (       u32) => adapter = |n:u32| n + 2       );
@@ -155,7 +155,7 @@ error: `skip` may not be used with any other attributes
 error: `skip` may not be used with any other attributes
   --> tests/ui/skip-conficts.fail.rs:8:23
    |
- 8 |             #[builder(skip, $($tt)*)]
+8  |             #[builder(skip, $($tt)*)]
    |                       ^^^^
 ...
 31 | define!(BeforeRename,     AfterRename     as (       u32) => rename = "renamed"            );
@@ -177,7 +177,7 @@ error: `skip` may not be used with any other attributes
 error: `skip` may not be used with any other attributes
   --> tests/ui/skip-conficts.fail.rs:8:23
    |
- 8 |             #[builder(skip, $($tt)*)]
+8  |             #[builder(skip, $($tt)*)]
    |                       ^^^^
 ...
 32 | define!(BeforeSkipPrefix, AfterSkipPrefix as (       u32) => skip_prefix                   );
@@ -199,7 +199,7 @@ error: `skip` may not be used with any other attributes
 error: `skip` may not be used with any other attributes
   --> tests/ui/skip-conficts.fail.rs:8:23
    |
- 8 |             #[builder(skip, $($tt)*)]
+8  |             #[builder(skip, $($tt)*)]
    |                       ^^^^
 ...
 33 | define!(BeforeSkipSuffix, AfterSkipSuffix as (       u32) => skip_suffix                   );
@@ -221,7 +221,7 @@ error: `skip` may not be used with any other attributes
 error: `skip` may not be used with any other attributes
   --> tests/ui/skip-conficts.fail.rs:8:23
    |
- 8 |             #[builder(skip, $($tt)*)]
+8  |             #[builder(skip, $($tt)*)]
    |                       ^^^^
 ...
 34 | define!(BeforeAttributes, AfterAttributes as (       u32) => attributes()                  );
@@ -243,7 +243,7 @@ error: `skip` may not be used with any other attributes
 error: `skip` may not be used with any other attributes
   --> tests/ui/skip-conficts.fail.rs:8:23
    |
- 8 |             #[builder(skip, $($tt)*)]
+8  |             #[builder(skip, $($tt)*)]
    |                       ^^^^
 ...
 35 | define!(BeforeDoc,        AfterDoc        as (       u32) => doc()                         );

--- a/bauer/tests/ui/type-state-range.fail.stderr
+++ b/bauer/tests/ui/type-state-range.fail.stderr
@@ -1,7 +1,7 @@
 error[E0599]: the method `build` exists for struct `RangeInclusiveBuilder<RangeInclusive_FieldA_Count<((), ())>>`, but its trait bounds were not satisfied
   --> tests/ui/type-state-range.fail.rs:32:66
    |
- 3 | #[derive(Builder)]
+3  | #[derive(Builder)]
    |          ------- method `build` not found for this struct because it doesn't satisfy `_: RangeInclusive<2, 3>`
 ...
 32 |     let _: RangeInclusive = RangeInclusive::builder().field_a(1).build(); // fail b/c <2
@@ -10,7 +10,7 @@ error[E0599]: the method `build` exists for struct `RangeInclusiveBuilder<RangeI
 note: trait bound `RangeInclusive_FieldA_Count<((), ())>: bauer::state::RangeInclusive<2, 3>` was not satisfied
   --> tests/ui/type-state-range.fail.rs:3:10
    |
- 3 | #[derive(Builder)]
+3  | #[derive(Builder)]
    |          ^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: the trait `bauer::state::RangeInclusive` must be implemented
   --> src/lib.rs
@@ -22,7 +22,7 @@ note: the trait `bauer::state::RangeInclusive` must be implemented
 error[E0599]: the method `build` exists for struct `RangeInclusiveBuilder<RangeInclusive_FieldA_Count<(((((), ()), ()), ()), ())>>`, but its trait bounds were not satisfied
   --> tests/ui/type-state-range.fail.rs:38:10
    |
- 3 |   #[derive(Builder)]
+3  |   #[derive(Builder)]
    |            ------- method `build` not found for this struct because it doesn't satisfy `_: RangeInclusive<2, 3>`
 ...
 33 |       let _: RangeInclusive = RangeInclusive::builder()
@@ -39,7 +39,7 @@ error[E0599]: the method `build` exists for struct `RangeInclusiveBuilder<RangeI
 note: trait bound `RangeInclusive_FieldA_Count<(((((), ()), ()), ()), ())>: bauer::state::RangeInclusive<2, 3>` was not satisfied
   --> tests/ui/type-state-range.fail.rs:3:10
    |
- 3 | #[derive(Builder)]
+3  | #[derive(Builder)]
    |          ^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: the trait `bauer::state::RangeInclusive` must be implemented
   --> src/lib.rs

--- a/bauer/tests/ui/type-state-require-field.fail.stderr
+++ b/bauer/tests/ui/type-state-require-field.fail.stderr
@@ -1,7 +1,7 @@
 error[E0599]: no method named `build` found for struct `FooBuilder<Foo_FieldA_Set<false>>` in the current scope
   --> tests/ui/type-state-require-field.fail.rs:10:35
    |
- 3 | #[derive(Builder)]
+3  | #[derive(Builder)]
    |          ------- method `build` not found for this struct
 ...
 10 |     let foo: Foo = Foo::builder().build(); // fail


### PR DESCRIPTION
Resolve #60 

Opted to use the following syntax for substitution:

```rust
#[builder(on(Box<[_]> => repeat = #0))]
```

This change also makes it so that the `#[builder(..)]` attribute on fields and structs can be repeated:

```rust
#[derive(Builder)]
#[builder(kind = "type-state")]
#[builder(on(String => into))]
struct Foo {}
```