### PR TITLE
fix: allow tuple attribute on Option<(T, U)> fields

### DIFF
--- a/bauer-macros/src/attr/field.rs
+++ b/bauer-macros/src/attr/field.rs
@@ -1084,7 +1084,11 @@ impl FieldAttr {
                         bail!(ident.span() => "`tuple` cannot be added with `adapter`");
                     }
 
-                    let tuple = match &field.ty {
+                    // Peel a single Option layer so `Option<(T, U)>` is treated as a tuple field.
+                    let effective_ty =
+                        get_single_generic(&field.ty, Some("Option")).unwrap_or(&field.ty);
+
+                    let tuple = match effective_ty {
                         Type::Tuple(tuple) => tuple,
                         _ => match &self.repeat {
                             Some(Repeat {

--- a/bauer/tests/optional_tuple.rs
+++ b/bauer/tests/optional_tuple.rs
@@ -1,0 +1,40 @@
+#![allow(dead_code)]
+
+macro_rules! tests {
+    ($kind: literal in mod $module: ident) => {
+        mod $module {
+            use bauer::Builder;
+
+            #[derive(Debug, Builder, PartialEq)]
+            #[builder(kind = $kind)]
+            struct OptionalTuple {
+                #[builder(tuple)]
+                bar: Option<(u32, u32)>,
+                #[builder(tuple(a, b))]
+                named: Option<(i32, i32)>,
+            }
+
+            #[test]
+            fn optional_tuple_unset_is_none() {
+                let f: OptionalTuple = OptionalTuple::builder().build();
+                assert_eq!(f.bar, None);
+                assert_eq!(f.named, None);
+            }
+
+            #[test]
+            fn optional_tuple_set_with_separate_args() {
+                let f: OptionalTuple = OptionalTuple::builder()
+                    .bar(1, 2)
+                    .named(3, 4)
+                    .build();
+
+                assert_eq!(f.bar, Some((1, 2)));
+                assert_eq!(f.named, Some((3, 4)));
+            }
+        }
+    };
+}
+
+tests!("borrowed" in mod borrowed);
+tests!("owned" in mod owned);
+tests!("type-state" in mod type_state);


### PR DESCRIPTION
## Summary
- `#[builder(tuple)]` previously matched only the raw field type, so `Option<(T, U)>` failed with `` `tuple` may only be used on fields that are tuples ``.
- Peel one `Option` layer during attribute parsing (same as other Option field handling) and add regression tests covering borrowed/owned/type-state builders.

## Test plan
- [x] `cargo test -p bauer --test optional_tuple`
- [x] `cargo test -p bauer --test complex --test dup --test simple`

Fixes #89